### PR TITLE
Makefile: move sdl-config logic to common.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,13 +34,6 @@ ifndef CFLAGS
 CFLAGS = $(MACHINE) -ftree-vectorize
 endif
 
-# What include flags to pass to the compiler
-ifdef COMSPEC
-	SDLFLAGS = -I c:/MinGW/include/SDL2 -lSDL2 -lwinmm
-else
-	SDLFLAGS = `sdl2-config --cflags` -U_FORTIFY_SOURCE
-endif
-
 INCLUDEFLAGS= -I ../Common -I src $(SDLFLAGS) -I src/gfx -I src/snd -I src/util -I src/gui $(EXTFLAGS)
 
 # Separate compile options per configuration

--- a/common.mk
+++ b/common.mk
@@ -7,3 +7,12 @@ Q=@
 MSG=@$(ECHO)
 endif
 
+# SDL include/lib flags to pass to the compiler
+ifdef COMSPEC
+	SDLFLAGS := -I c:/MinGW/include/SDL2 -lSDL2 -lwinmm
+	SDLLIBS :=  -lSDL2main -lSDL2 -lSDL2_image -lwinmm
+else
+	SDLFLAGS := $(shell sdl2-config --cflags) -U_FORTIFY_SOURCE
+	SDLLIBS := $(shell sdl2-config --libs) -lSDL2_image
+endif
+


### PR DESCRIPTION
also evaluate the result of the call only once to speed up the build,
rather than running it for every single TU.