### PR TITLE
Adjust envelope value to smooth transition from attack to release

### DIFF
--- a/src/snd/cyd.c
+++ b/src/snd/cyd.c
@@ -997,10 +997,22 @@ void cyd_enable_gate(CydEngine *cyd, CydChannel *chn, Uint8 enable)
 	else
 	{
 		chn->flags &= ~CYD_CHN_WAVE_OVERRIDE_ENV;
+		// Adjust envelope value to create a continuous transition between attack and release
+		if (chn->adsr.envelope_state == ATTACK)
+		{
+			float fenv = sqrtf((float)chn->adsr.envelope * (float)(65536*256));
+			chn->adsr.envelope = fenv;
+		}
 		chn->adsr.envelope_state = RELEASE;
 		chn->adsr.env_speed = envspd(cyd, chn->adsr.r);
 		
 #ifndef CYD_DISABLE_FM
+		// Adjust envelope value to create a continuous modulator transition between attack and release
+		if (chn->fm.adsr.envelope_state == ATTACK)
+		{
+			float fenv = sqrtf((float)chn->fm.adsr.envelope * (float)(65536*256));
+			chn->fm.adsr.envelope = fenv;
+		}
 		chn->fm.adsr.envelope_state = RELEASE;
 		chn->fm.adsr.env_speed = envspd(cyd, chn->fm.adsr.r);
 #endif		

--- a/src/snd/cyd.c
+++ b/src/snd/cyd.c
@@ -51,7 +51,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 #define envspd(cyd,slope) (slope!=0?(((Uint64)0xff0000 / ((slope) * (slope) * 256 / (ENVELOPE_SCALE * ENVELOPE_SCALE))) * CYD_BASE_FREQ / cyd->sample_rate):((Uint64)0xff0000 * CYD_BASE_FREQ / cyd->sample_rate))
 
-// used lfsr-generator <http://lfsr-generator.sourceforge.net/> for this: 
+// used lfsr-generator <http://lfsr-generator.sourceforge.net/> for this:
 
 inline static void shift_lfsr(Uint32 *v, int tap_0, int tap_1)
 {
@@ -80,7 +80,7 @@ static void cyd_init_channel(CydEngine *cyd, CydChannel *chn)
 		chn->subosc[s].random = RANDOM_SEED;
 		chn->subosc[s].reg4 = chn->subosc[s].reg5 = chn->subosc[s].reg9 = 1;
 	}
-	
+
 #ifndef CYD_DISABLE_FM
 	cydfm_init(&chn->fm);
 #endif
@@ -93,14 +93,14 @@ static void cyd_init_log_tables(CydEngine *cyd)
 	{
 		cyd->lookup_table[i] = i * (i/2) / ((LUT_SIZE*LUT_SIZE / 65536)/2);
 	}
-	
+
 #ifndef CYD_DISABLE_BUZZ
 	for (int i = 0 ; i < YM_LUT_SIZE ; ++i)
 	{
 		static const int ymVolumeTable[16] = { 62,161,265,377,580,774,1155,1575,2260,3088,4570,6233,9330,13187,21220,32767}; // from leonard's code
 		cyd->lookup_table_ym[i] = ymVolumeTable[i]; //(Uint32)32767 * (Uint32)(i+1) * (Uint32)(i+1) * (Uint32)(i+1) / (Uint32)(YM_LUT_SIZE * YM_LUT_SIZE * YM_LUT_SIZE);
 	}
-	
+
 	cyd->lookup_table_ym[0] = 0;
 #endif
 }
@@ -128,7 +128,7 @@ void cyd_init(CydEngine *cyd, Uint16 sample_rate, int channels)
 #ifndef CYD_DISABLE_BUZZ
 	cyd->lookup_table_ym = malloc(sizeof(*cyd->lookup_table) * YM_LUT_SIZE);
 #endif
-	
+
 #ifndef USENATIVEAPIS
 
 # ifdef USESDLMUTEXES
@@ -143,17 +143,17 @@ void cyd_init(CydEngine *cyd, Uint16 sample_rate, int channels)
 # endif
 
 #endif
-	
+
 	cyd_init_log_tables(cyd);
-	
+
 	for (int i = 0 ; i < CYD_MAX_FX_CHANNELS ; ++i)
 		cydfx_init(&cyd->fx[i], sample_rate);
 #ifndef CYD_DISABLE_WAVETABLE
 	cyd->wavetable_entries = calloc(sizeof(cyd->wavetable_entries[0]), CYD_WAVE_MAX_ENTRIES);
-	
+
 	cyd_reset_wavetable(cyd);
 #endif
-	
+
 	cyd_reserve_channels(cyd, channels);
 }
 
@@ -170,17 +170,17 @@ void cyd_reserve_channels(CydEngine *cyd, int channels)
 	cyd_lock(cyd, 1);
 
 	cyd->n_channels = channels;
-	
+
 	if (cyd->n_channels > CYD_MAX_CHANNELS)
 		cyd->n_channels = CYD_MAX_CHANNELS;
-	
+
 	if (cyd->channel)
 		free(cyd->channel);
-	
+
 	cyd->channel = calloc(sizeof(*cyd->channel), CYD_MAX_CHANNELS);
-	
+
 	cyd_reset(cyd);
-	
+
 	cyd_lock(cyd, 0);
 }
 
@@ -192,9 +192,9 @@ void cyd_deinit(CydEngine *cyd)
 		free(cyd->lookup_table);
 		cyd->lookup_table = NULL;
 	}
-	
+
 #ifndef CYD_DISABLE_BUZZ
-	if (cyd->lookup_table_ym)	
+	if (cyd->lookup_table_ym)
 	{
 		free(cyd->lookup_table_ym);
 		cyd->lookup_table_ym = NULL;
@@ -206,17 +206,17 @@ void cyd_deinit(CydEngine *cyd)
 		free(cyd->channel);
 		cyd->channel = NULL;
 	}
-	
+
 	for (int i = 0 ; i < CYD_MAX_FX_CHANNELS ; ++i)
 		cydfx_deinit(&cyd->fx[i]);
-	
+
 #ifndef USENATIVEAPIS
 
 # ifdef USESDLMUTEXES
 	if (cyd->mutex)
 		SDL_DestroyMutex(cyd->mutex);
 	cyd->mutex = NULL;
-# endif	
+# endif
 
 #else
 
@@ -232,7 +232,7 @@ void cyd_deinit(CydEngine *cyd)
 	{
 		for (int i = 0 ; i < CYD_WAVE_MAX_ENTRIES ; ++i)
 			cyd_wave_entry_deinit(&cyd->wavetable_entries[i]);
-			
+
 		free(cyd->wavetable_entries);
 		cyd->wavetable_entries = NULL;
 	}
@@ -261,22 +261,22 @@ Uint32 cyd_cycle_adsr(const CydEngine *eng, Uint32 flags, Uint32 ym_env_shape, C
 		{
 			case SUSTAIN:
 			case DONE: return flags; break;
-			
+
 			case ATTACK:
-			
+
 			adsr->envelope += adsr->env_speed;
-			
-			if (adsr->envelope >= 0xff0000) 
+
+			if (adsr->envelope >= 0xff0000)
 			{
 				adsr->envelope_state = DECAY;
 				adsr->envelope=0xff0000;
 				adsr->env_speed = envspd(eng, adsr->d);
 			}
-			
+
 			break;
-			
+
 			case DECAY:
-			
+
 				if (adsr->envelope > ((Uint32)adsr->s << 19) + adsr->env_speed)
 					adsr->envelope -= adsr->env_speed;
 				else
@@ -285,15 +285,15 @@ Uint32 cyd_cycle_adsr(const CydEngine *eng, Uint32 flags, Uint32 ym_env_shape, C
 					adsr->envelope_state = (adsr->s == 0) ? RELEASE : SUSTAIN;
 					adsr->env_speed = envspd(eng, adsr->r);;
 				}
-			
+
 			break;
-			
+
 			case RELEASE:
 			if (adsr->envelope > adsr->env_speed)
 			{
 				adsr->envelope -= adsr->env_speed;
 			}
-			else 
+			else
 			{
 				adsr->envelope_state = DONE;
 				if ((flags & (CYD_CHN_ENABLE_WAVE|CYD_CHN_WAVE_OVERRIDE_ENV)) != (CYD_CHN_ENABLE_WAVE|CYD_CHN_WAVE_OVERRIDE_ENV)) flags &= ~CYD_CHN_ENABLE_GATE;
@@ -305,16 +305,16 @@ Uint32 cyd_cycle_adsr(const CydEngine *eng, Uint32 flags, Uint32 ym_env_shape, C
 	}
 	else
 	{
-#ifndef CYD_DISABLE_BUZZ	
+#ifndef CYD_DISABLE_BUZZ
 		// YM2149 style envelope HOLD is not processed
-	
+
 		switch (adsr->envelope_state)
 		{
 			case ATTACK:
-			
+
 				adsr->envelope += adsr->env_speed;
-				
-				if (adsr->envelope >= YM_LENGTH) 
+
+				if (adsr->envelope >= YM_LENGTH)
 				{
 					if (ym_env_shape & CYD_YM_ENV_ALT)
 					{
@@ -327,12 +327,12 @@ Uint32 cyd_cycle_adsr(const CydEngine *eng, Uint32 flags, Uint32 ym_env_shape, C
 						adsr->envelope_state = ATTACK;
 					}
 				}
-			
+
 			break;
-			
+
 			case DECAY:
-			
-				if (adsr->envelope >= adsr->env_speed) 
+
+				if (adsr->envelope >= adsr->env_speed)
 					adsr->envelope -= adsr->env_speed;
 				else
 				{
@@ -345,23 +345,23 @@ Uint32 cyd_cycle_adsr(const CydEngine *eng, Uint32 flags, Uint32 ym_env_shape, C
 					{
 						adsr->envelope -= adsr->env_speed;
 						adsr->envelope &= YM_LENGTH - 1;
-						adsr->envelope_state = DECAY;		
+						adsr->envelope_state = DECAY;
 					}
 				}
-			
+
 			break;
-			
+
 			case RELEASE:
 				adsr->envelope_state = DONE;
 				if ((flags & (CYD_CHN_ENABLE_WAVE|CYD_CHN_WAVE_OVERRIDE_ENV)) != (CYD_CHN_ENABLE_WAVE|CYD_CHN_WAVE_OVERRIDE_ENV)) flags &= ~CYD_CHN_ENABLE_GATE;
 				adsr->envelope = 0;
 			break;
-			
+
 			default: break;
 		}
 #endif
 	}
-	
+
 	return flags;
 }
 
@@ -373,7 +373,7 @@ static void run_lfsrs(CydChannel *chn)
 	{
 		shift_lfsr(&chn->subosc[s].reg4, 4, 3);
 		shift_lfsr(&chn->subosc[s].reg5, 5, 3);
-		
+
 		if (chn->lfsr_type & 8)
 			shift_lfsr(&chn->subosc[s].reg9, 9, 5);
 		else
@@ -386,15 +386,15 @@ static void run_lfsrs(CydChannel *chn)
 static void cyd_cycle_channel(CydEngine *cyd, CydChannel *chn)
 {
 	chn->flags = cyd_cycle_adsr(cyd, chn->flags, chn->ym_env_shape, &chn->adsr);
-	
-	if (chn->flags & CYD_CHN_ENABLE_WAVE) 
+
+	if (chn->flags & CYD_CHN_ENABLE_WAVE)
 	{
 		for (int i = 0 ; i < CYD_SUB_OSCS ; ++i)
 		{
 			cyd_wave_cycle(&chn->subosc[i].wave, chn->wave_entry);
 		}
 	}
-	
+
 #ifndef CYD_DISABLE_FM
 	if (chn->flags & CYD_CHN_ENABLE_FM) cydfm_cycle(cyd, &chn->fm);
 #endif
@@ -427,14 +427,14 @@ static void cyd_advance_oscillators(CydEngine *cyd, CydChannel *chn)
 	{
 		Uint32 prev_acc = chn->subosc[s].accumulator;
 		chn->subosc[s].accumulator = (chn->subosc[s].accumulator + (Uint32)chn->subosc[s].frequency);
-		
+
 		/* only subosc #0 can set the sync bit */
-		
+
 		if (s == 0)
 			chn->sync_bit |= chn->subosc[s].accumulator & ACC_LENGTH;
-			
+
 		chn->subosc[s].accumulator &= ACC_LENGTH - 1;
-		
+
 		if ((prev_acc & (ACC_LENGTH/32)) != (chn->subosc[s].accumulator & (ACC_LENGTH/32)))
 		{
 			if (chn->flags & CYD_CHN_ENABLE_METAL)
@@ -448,48 +448,48 @@ static void cyd_advance_oscillators(CydEngine *cyd, CydChannel *chn)
 				chn->subosc[s].random &= (1 << (22 + 1)) - 1;
 			}
 		}
-	
-#ifndef CYD_DISABLE_LFSR		
+
+#ifndef CYD_DISABLE_LFSR
 		if (chn->flags & CYD_CHN_ENABLE_LFSR)
 		{
 			chn->subosc[s].lfsr_acc = (chn->subosc[s].lfsr & 1) ? (WAVE_AMP - 1) : 0;
-			
+
 			if (chn->subosc[s].lfsr_ctr >= chn->subosc[s].lfsr_period)
 			{
 				chn->subosc[s].lfsr_ctr = 0;
-			
+
 				switch (chn->lfsr_type & 3)
 				{
-					case 0: 
+					case 0:
 						chn->subosc[s].lfsr ^= !!(chn->subosc[s].reg5 & chn->subosc[s].reg9 & 1);
 						break;
-					
+
 					case 1:
-					case 3: 
+					case 3:
 						chn->subosc[s].lfsr ^= !!(chn->subosc[s].reg5 & 1);
 						break;
-					
+
 					case 2:
 						chn->subosc[s].lfsr ^= !!(chn->subosc[s].reg5 & chn->subosc[s].reg4 & 1);
 						break;
-						
-					case 4: 
+
+					case 4:
 						chn->subosc[s].lfsr ^= !!(chn->subosc[s].reg9 & 1);
 						break;
-						
-					case 5: 
+
+					case 5:
 					case 7:
 						chn->subosc[s].lfsr ^= 1;
 						break;
-						
-					case 6: 
+
+					case 6:
 						chn->subosc[s].lfsr ^= !!(chn->subosc[s].reg4 & 1);
 						break;
 				}
 			}
-			
+
 			++chn->subosc[s].lfsr_ctr;
-			
+
 			run_lfsrs(chn);
 		}
 #endif
@@ -500,13 +500,13 @@ static void cyd_advance_oscillators(CydEngine *cyd, CydChannel *chn)
 static Sint32 cyd_output_channel(CydEngine *cyd, CydChannel *chn)
 {
 	Sint32 ovr = 0;
-	
+
 	chn->sync_bit = 0;
 
-#ifndef CYD_DISABLE_FM	
+#ifndef CYD_DISABLE_FM
 	const Uint32 mod = (chn->flags & CYD_CHN_ENABLE_FM) ? cydfm_modulate(cyd, &chn->fm, 0) : 0;
 #endif
-	
+
 	for (int i = 0 ; i < (1 << cyd->oversample) ; ++i)
 	{
 		for (int s = 0 ; s < CYD_SUB_OSCS ; ++s)
@@ -517,18 +517,18 @@ static Sint32 cyd_output_channel(CydEngine *cyd, CydChannel *chn)
 				Uint32 accumulator = chn->subosc[s].accumulator;
 #else
 				Uint32 accumulator = chn->subosc[s].accumulator + mod;
-#endif	
+#endif
 				ovr += cyd_osc(chn->flags, accumulator % ACC_LENGTH, chn->pw, chn->subosc[s].random, chn->subosc[s].lfsr_acc) - WAVE_AMP / 2;
 			}
 		}
-		
+
 		cyd_advance_oscillators(cyd, chn); // Need to move the oscillators per every oversample subcycle
-		
+
 #ifndef CYD_DISABLE_FM
 		cydfm_cycle_oversample(cyd, &chn->fm);
 #endif
 	}
-	
+
 	return (ovr >> cyd->oversample);
 }
 
@@ -537,7 +537,7 @@ Sint32 cyd_env_output(const CydEngine *cyd, Uint32 chn_flags, const CydAdsr *ads
 {
 	if (chn_flags & CYD_CHN_ENABLE_YM_ENV)
 	{
-#ifndef CYD_DISABLE_BUZZ	
+#ifndef CYD_DISABLE_BUZZ
 		int idx = adsr->envelope * (Uint32)YM_LUT_SIZE / YM_LENGTH;
 		return input * cyd->lookup_table_ym[idx % YM_LUT_SIZE] / 32768 * (Sint32)(adsr->volume) / MAX_VOLUME;
 #else
@@ -546,7 +546,7 @@ Sint32 cyd_env_output(const CydEngine *cyd, Uint32 chn_flags, const CydAdsr *ads
 	}
 	else
 	{
-#ifndef CYD_DISABLE_ENVELOPE	
+#ifndef CYD_DISABLE_ENVELOPE
 		if (adsr->envelope_state == ATTACK)
 			return ((Sint64)input * ((Sint32)adsr->envelope / 0x10000) / 256) * (Sint32)(adsr->volume) / MAX_VOLUME;
 		else
@@ -571,7 +571,7 @@ static Sint32 cyd_output(CydEngine *cyd)
 	Sint32 v = 0, fx_input[CYD_MAX_FX_CHANNELS] = {0};
 #endif
 	Sint32 s[CYD_MAX_CHANNELS];
-	
+
 	for (int i = 0 ; i < cyd->n_channels ; ++i)
 	{
 		s[i] = (Sint32)cyd_output_channel(cyd, &cyd->channel[i]);
@@ -586,14 +586,14 @@ static Sint32 cyd_output(CydEngine *cyd)
 					CydWaveAcc accumulator = cyd->channel[i].subosc[sub].wave.acc;
 #else
 					CydWaveAcc accumulator = (cyd->channel[i].flags & CYD_CHN_ENABLE_FM) ? cydfm_modulate_wave(cyd, &cyd->channel[i].fm, cyd->channel[i].wave_entry, cyd->channel[i].subosc[sub].wave.acc) : cyd->channel[i].subosc[sub].wave.acc;
-#endif	
+#endif
 					s[i] += cyd_wave_get_sample(&cyd->channel[i].subosc[sub].wave, cyd->channel[i].wave_entry, accumulator);
 				}
 			}
 		}
 #endif
 	}
-	
+
 	for (int i = 0 ; i < cyd->n_channels ; ++i)
 	{
 		CydChannel *chn = &cyd->channel[i];
@@ -609,7 +609,7 @@ static Sint32 cyd_output(CydEngine *cyd)
 				o = cyd_env_output(cyd, chn->flags, &chn->adsr, s[i]);
 			}
 
-#ifndef CYD_DISABLE_WAVETABLE			
+#ifndef CYD_DISABLE_WAVETABLE
 			if ((cyd->channel[i].flags & CYD_CHN_ENABLE_WAVE) && cyd->channel[i].wave_entry && (cyd->channel[i].flags & CYD_CHN_WAVE_OVERRIDE_ENV))
 			{
 				for (int s = 0 ; s < CYD_SUB_OSCS ; ++s)
@@ -620,7 +620,7 @@ static Sint32 cyd_output(CydEngine *cyd)
 						CydWaveAcc accumulator = cyd->channel[i].subosc[s].wave.acc;
 #else
 						CydWaveAcc accumulator = (cyd->channel[i].flags & CYD_CHN_ENABLE_FM) ? cydfm_modulate_wave(cyd, &cyd->channel[i].fm, cyd->channel[i].wave_entry, cyd->channel[i].subosc[s].wave.acc) : cyd->channel[i].subosc[s].wave.acc;
-#endif	
+#endif
 						o += cyd_wave_get_sample(&cyd->channel[i].subosc[s].wave, chn->wave_entry, accumulator) * (Sint32)(chn->adsr.volume) / MAX_VOLUME;
 					}
 				}
@@ -628,7 +628,7 @@ static Sint32 cyd_output(CydEngine *cyd)
 #endif
 
 #ifndef CYD_DISABLE_FILTER
-			if (chn->flags & CYD_CHN_ENABLE_FILTER) 
+			if (chn->flags & CYD_CHN_ENABLE_FILTER)
 			{
 				cydflt_cycle(&chn->flt, o);
 				switch (chn->flttype)
@@ -639,10 +639,10 @@ static Sint32 cyd_output(CydEngine *cyd)
 				}
 			}
 #endif
-			
+
 #ifdef STEREOOUTPUT
 			Sint32 ol = o * chn->gain_left / CYD_STEREO_GAIN, or = o * chn->gain_right / CYD_STEREO_GAIN;
-#endif		
+#endif
 
 			if (chn->flags & CYD_CHN_ENABLE_FX)
 			{
@@ -660,11 +660,11 @@ static Sint32 cyd_output(CydEngine *cyd)
 				*right += or;
 #else
 				v += o;
-#endif		
+#endif
 			}
 		}
 	}
-	
+
 	for (int i = 0 ; i < CYD_MAX_FX_CHANNELS ; ++i)
 	{
 #ifdef STEREOOUTPUT
@@ -676,7 +676,7 @@ static Sint32 cyd_output(CydEngine *cyd)
 		v += cydfx_output(&cyd->fx[i], fx_input[i]);
 #endif
 	}
-	
+
 #ifndef STEREOOUTPUT
 	return v;
 #endif
@@ -689,7 +689,7 @@ static void cyd_cycle(CydEngine *cyd)
 	{
 		cyd_cycle_channel(cyd, &cyd->channel[i]);
 	}
-	
+
 	for (int i = 0 ; i < cyd->n_channels ; ++i)
 	{
 		cyd_sync_channel(cyd, &cyd->channel[i]);
@@ -706,17 +706,17 @@ void cyd_output_buffer(int chan, void *_stream, int len, void *udata)
 	CydEngine *cyd = udata;
 	Sint16 * stream = (void*)_stream;
 	cyd->samples_output = 0;
-	
+
 	for (int i = 0 ; i < len ; i += sizeof(Sint16), ++stream, ++cyd->samples_output)
 	{
-	
+
 #ifndef USENATIVEAPIS
 
 #ifndef USESDLMUTEXES
 #ifdef DEBUG
 		Uint32 waittime = SDL_GetTicks();
 #endif
-		while (cyd->lock_request) 
+		while (cyd->lock_request)
 		{
 #ifdef DEBUG
 			if (SDL_GetTicks() - waittime > 5000)
@@ -730,19 +730,19 @@ void cyd_output_buffer(int chan, void *_stream, int len, void *udata)
 #endif
 
 #endif
-	
-		if (cyd->flags & CYD_PAUSED) 
-		{ 
-			i += BUFFER_GRANULARITY * 2 * sizeof(Sint16); 
+
+		if (cyd->flags & CYD_PAUSED)
+		{
+			i += BUFFER_GRANULARITY * 2 * sizeof(Sint16);
 			stream += BUFFER_GRANULARITY * 2;
-			continue; 
+			continue;
 		}
-		
+
 		cyd_lock(cyd, 1);
-		
+
 		for (int g = 0 ; g < BUFFER_GRANULARITY && i < len ; i += sizeof(Sint16)*2, stream += 2, ++cyd->samples_output)
 		{
-		
+
 			if (cyd->callback && cyd->callback_counter-- == 0)
 			{
 				cyd->callback_counter = cyd->callback_period-1;
@@ -752,7 +752,7 @@ void cyd_output_buffer(int chan, void *_stream, int len, void *udata)
 					return;
 				}
 			}
-			
+
 #ifdef STEREOOUTPUT
 			Sint32 output, left, right;
 			cyd_output(cyd, &left, &right);
@@ -766,18 +766,18 @@ void cyd_output_buffer(int chan, void *_stream, int len, void *udata)
 #else
 			Sint32 o = (Sint32)*(Sint16*)stream + (output * PRE_GAIN) / PRE_GAIN_DIVISOR;
 #endif
-			
+
 			if (o < -32768) o = -32768;
 			else if (o > 32767) o = 32767;
-			
+
 			*(Sint16*)stream = o;
-			
+
 			cyd_cycle(cyd);
 		}
 
 		cyd_lock(cyd, 0);
 	}
-	
+
 }
 
 
@@ -791,16 +791,16 @@ void cyd_output_buffer_stereo(int chan, void *_stream, int len, void *udata)
 	Sint16 *stream = (void*)_stream;
 	cyd->samples_output = 0;
 	cyd->flags &= ~CYD_CLIPPING;
-	
+
 	for (int i = 0 ; i < len ; )
 	{
 #ifndef USENATIVEAPIS
-	
+
 #ifndef USESDLMUTEXES
 #ifdef DEBUG
 		Uint32 waittime = SDL_GetTicks();
 #endif
-		while (cyd->lock_request) 
+		while (cyd->lock_request)
 		{
 #ifdef DEBUG
 			if (SDL_GetTicks() - waittime > 5000)
@@ -814,19 +814,19 @@ void cyd_output_buffer_stereo(int chan, void *_stream, int len, void *udata)
 #endif
 
 #endif
-	
-		if (cyd->flags & CYD_PAUSED) 
-		{ 
-			i += BUFFER_GRANULARITY * 2 * sizeof(Sint16); 
+
+		if (cyd->flags & CYD_PAUSED)
+		{
+			i += BUFFER_GRANULARITY * 2 * sizeof(Sint16);
 			stream += BUFFER_GRANULARITY * 2;
-			continue; 
+			continue;
 		}
-		
+
 		cyd_lock(cyd, 1);
-		
+
 		for (int g = 0 ; g < BUFFER_GRANULARITY && i < len ; i += sizeof(Sint16)*2, stream += 2, ++cyd->samples_output)
 		{
-		
+
 			if (cyd->callback && cyd->callback_counter-- == 0)
 			{
 				cyd->callback_counter = cyd->callback_period-1;
@@ -849,18 +849,18 @@ void cyd_output_buffer_stereo(int chan, void *_stream, int len, void *udata)
 #else
 			Sint32 o1 = (Sint32)*(Sint16*)stream + (left * PRE_GAIN) / PRE_GAIN_DIVISOR;
 #endif
-			
-			if (o1 < -32768) 
+
+			if (o1 < -32768)
 			{
 				o1 = -32768;
 				cyd->flags |= CYD_CLIPPING;
 			}
-			else if (o1 > 32767) 
+			else if (o1 > 32767)
 			{
 				o1 = 32767;
 				cyd->flags |= CYD_CLIPPING;
 			}
-			
+
 			*(Sint16*)stream = o1;
 
 #ifdef NOSDL_MIXER
@@ -868,24 +868,24 @@ void cyd_output_buffer_stereo(int chan, void *_stream, int len, void *udata)
 #else
 			Sint32 o2 = (Sint32)*((Sint16*)stream + 1) + (right * PRE_GAIN) / PRE_GAIN_DIVISOR;
 #endif
-			
-			if (o2 < -32768) 
+
+			if (o2 < -32768)
 			{
 				o2 = -32768;
 				cyd->flags |= CYD_CLIPPING;
 			}
-			else if (o2 > 32767) 
+			else if (o2 > 32767)
 			{
 				o2 = 32767;
 				cyd->flags |= CYD_CLIPPING;
 			}
-			
+
 			*((Sint16*)stream + 1) = o2;
-			
+
 			cyd_cycle(cyd);
 			++cyd->samples_played;
 		}
-		
+
 		cyd_lock(cyd, 0);
 	}
 }
@@ -897,13 +897,13 @@ void cyd_set_frequency(CydEngine *cyd, CydChannel *chn, int subosc, Uint16 frequ
 	{
 		chn->subosc[subosc].frequency = (Uint64)(ACC_LENGTH >> (cyd->oversample))/16 * (Uint64)(frequency) / (Uint64)cyd->sample_rate;
 
-#ifndef CYD_DISABLE_LFSR	
+#ifndef CYD_DISABLE_LFSR
 		chn->subosc[subosc].lfsr_period = (Uint64)cyd->sample_rate * 16 / frequency;
 #endif
 	}
 	else
 		chn->subosc[subosc].frequency = 0;
-	
+
 #ifndef CYD_DISABLE_FM
 	if (subosc == 0)
 		cydfm_set_frequency(cyd, &chn->fm, frequency);
@@ -912,7 +912,7 @@ void cyd_set_frequency(CydEngine *cyd, CydChannel *chn, int subosc, Uint16 frequ
 
 
 void cyd_set_wavetable_frequency(CydEngine *cyd, CydChannel *chn, int subosc, Uint16 frequency)
-{	
+{
 #ifndef CYD_DISABLE_WAVETABLE
 	if (frequency != 0 && chn->wave_entry)
 	{
@@ -939,7 +939,7 @@ void cyd_set_env_shape(CydChannel *chn, Uint8 shape)
 {
 #ifndef CYD_DISABLE_BUZZ
 	chn->ym_env_shape = shape;
-	
+
 	if ((chn->flags & CYD_CHN_ENABLE_KEY_SYNC) || (chn->adsr.envelope_state == DONE || chn->adsr.envelope_state == SUSTAIN))
 	{
 		if (shape & CYD_YM_ENV_ATT)
@@ -968,7 +968,7 @@ void cyd_enable_gate(CydEngine *cyd, CydChannel *chn, Uint8 enable)
 			chn->adsr.envelope = 0x0;
 			chn->adsr.env_speed = envspd(cyd, chn->adsr.a);
 			chn->flags = cyd_cycle_adsr(cyd, chn->flags, chn->ym_env_shape, &chn->adsr);
-#ifndef CYD_DISABLE_FM	
+#ifndef CYD_DISABLE_FM
 			chn->fm.adsr.envelope_state = ATTACK;
 			chn->fm.adsr.envelope = chn->fm.attack_start << 19;
 			chn->fm.adsr.env_speed = envspd(cyd, chn->fm.adsr.a);
@@ -976,7 +976,7 @@ void cyd_enable_gate(CydEngine *cyd, CydChannel *chn, Uint8 enable)
 #endif
 #endif
 		}
-		
+
 		if (chn->flags & CYD_CHN_ENABLE_KEY_SYNC)
 		{
 			for (int s = 0 ; s < CYD_SUB_OSCS ; ++s)
@@ -985,37 +985,45 @@ void cyd_enable_gate(CydEngine *cyd, CydChannel *chn, Uint8 enable)
 				chn->subosc[s].reg4 = chn->subosc[s].reg5 = chn->subosc[s].reg9 = 1;
 				chn->subosc[s].lfsr_ctr = 0;
 			}
-			
+
 #ifndef CYD_DISABLE_FM
 			chn->fm.accumulator = 0;
 			chn->fm.wave.acc = 0;
 #endif
 		}
-		
+
 		chn->flags |= CYD_CHN_ENABLE_GATE;
 	}
 	else
 	{
 		chn->flags &= ~CYD_CHN_WAVE_OVERRIDE_ENV;
+
+#ifndef CYD_OLD_ENVELOPE_RELEASE
 		// Adjust envelope value to create a continuous transition between attack and release
 		if (chn->adsr.envelope_state == ATTACK)
 		{
-			float fenv = sqrtf((float)chn->adsr.envelope * (float)(65536*256));
+			float fenv = sqrtf((float)chn->adsr.envelope * 65536.0f * 256.0f);
 			chn->adsr.envelope = fenv;
 		}
+#endif
+
 		chn->adsr.envelope_state = RELEASE;
 		chn->adsr.env_speed = envspd(cyd, chn->adsr.r);
-		
+
 #ifndef CYD_DISABLE_FM
+
+#ifndef CYD_OLD_ENVELOPE_RELEASE
 		// Adjust envelope value to create a continuous modulator transition between attack and release
 		if (chn->fm.adsr.envelope_state == ATTACK)
 		{
-			float fenv = sqrtf((float)chn->fm.adsr.envelope * (float)(65536*256));
+			float fenv = sqrtf((float)chn->fm.adsr.envelope * 65536.0f * 256.0f);
 			chn->fm.adsr.envelope = fenv;
 		}
+#endif
+
 		chn->fm.adsr.envelope_state = RELEASE;
 		chn->fm.adsr.env_speed = envspd(cyd, chn->fm.adsr.r);
-#endif		
+#endif
 	}
 }
 
@@ -1035,7 +1043,7 @@ void cyd_set_callback(CydEngine *cyd, int (*callback)(void*), void*param, Uint16
 	cyd->callback = callback;
 	cyd->callback_period = cyd->sample_rate / period;
 	cyd->callback_counter = cyd->callback_counter % cyd->callback_period;
-	
+
 	cyd_lock(cyd, 0);
 }
 
@@ -1043,10 +1051,10 @@ void cyd_set_callback(CydEngine *cyd, int (*callback)(void*), void*param, Uint16
 void cyd_set_callback_rate(CydEngine *cyd, Uint16 period)
 {
 	cyd_lock(cyd, 1);
-	
+
 	cyd->callback_period = cyd->sample_rate / period;
 	cyd->callback_counter = cyd->callback_counter % cyd->callback_period;
-	
+
 	cyd_lock(cyd, 0);
 }
 
@@ -1063,14 +1071,14 @@ static void fill_buffer(CydEngine *cyd)
 #else
 	cyd_output_buffer_stereo(0, cyd->waveout_hdr[cyd->waveout_hdr_idx].lpData, cyd->waveout_hdr[cyd->waveout_hdr_idx].dwBufferLength, cyd);
 #endif
-	
+
 	//waveOutPrepareHeader(cyd->hWaveOut, &cyd->waveout_hdr[cyd->waveout_hdr_idx],sizeof(WAVEHDR));
-	
+
 	cyd->waveout_hdr[cyd->waveout_hdr_idx].dwFlags = WHDR_PREPARED;
-	
+
 	if (waveOutWrite(cyd->hWaveOut, &cyd->waveout_hdr[cyd->waveout_hdr_idx], sizeof(cyd->waveout_hdr[cyd->waveout_hdr_idx])) != MMSYSERR_NOERROR)
 		warning("waveOutWrite returned error");
-	
+
 	if (++cyd->waveout_hdr_idx >= CYD_NUM_WO_BUFFERS)
 		cyd->waveout_hdr_idx = 0;
 }
@@ -1079,33 +1087,33 @@ static void fill_buffer(CydEngine *cyd)
 static DWORD WINAPI ThreadProc(void *param)
 {
 	CydEngine *cyd = param;
-	
+
 	for(;;)
 	{
 		EnterCriticalSection(&cyd->thread_lock);
-		
+
 		if (!cyd->thread_running)
 		{
 			LeaveCriticalSection(&cyd->thread_lock);
 			break;
 		}
-		
+
 		while (cyd->buffers_available > 0)
 		{
 			LeaveCriticalSection(&cyd->thread_lock);
 			fill_buffer(cyd);
 			EnterCriticalSection(&cyd->thread_lock);
 			--cyd->buffers_available;
-			
+
 		}
-		
+
 		LeaveCriticalSection(&cyd->thread_lock);
-		
+
 		Sleep(1);
 	}
-	
+
 	debug("Thread exit");
-	
+
 	return 0;
 }
 
@@ -1114,24 +1122,24 @@ static DWORD WINAPI waveOutProc(void *param)
 {
 	CydEngine *cyd = (void*)param;
 	MSG msg;
-	
+
 	while (GetMessage(&msg, 0, 0, 0) == 1)
 	{
 		if (msg.message == MM_WOM_DONE)
 		{
 			EnterCriticalSection(&cyd->thread_lock);
-			
+
 			++cyd->buffers_available;
-			
+
 			LeaveCriticalSection(&cyd->thread_lock);
 		}
-		
+
 		if (msg.message == MM_WOM_CLOSE)
 		{
 			break;
 		}
 	}
-	
+
 	return 0;
 }
 
@@ -1155,19 +1163,19 @@ int cyd_register(CydEngine * cyd)
 		{
 			case AUDIO_S16SYS:
 			break;
-			
+
 			default:
 			return 0;
 			break;
 		}
-	
+
 		switch (channels)
 		{
 			case 1: if (!Mix_RegisterEffect(MIX_CHANNEL_POST, cyd_output_buffer, NULL, cyd)) return 0; break;
 			case 2: if (!Mix_RegisterEffect(MIX_CHANNEL_POST, cyd_output_buffer_stereo, NULL, cyd)) return 0; break;
 			default: return 0; break;
 		}
-		
+
 		return 1;
 	}
 	else return 0;
@@ -1192,18 +1200,18 @@ int cyd_register(CydEngine * cyd)
 	desired.userdata=cyd;
 
 	debug("Opening SDL audio");
-	
+
 	/* Open the audio device */
 	if ( SDL_OpenAudio(&desired, &obtained) < 0 )
 	{
 		warning("Could not open audio device");
 		return 0;
 	}
-	
+
 	debug("Got %d Hz/format %d/%d channels", obtained.freq, obtained.format, obtained.channels);
-	
+
 	SDL_PauseAudio(0);
-	
+
 	return 1;
 # endif
 #else
@@ -1217,35 +1225,35 @@ int cyd_register(CydEngine * cyd)
     waveformat.nSamplesPerSec = cyd->sample_rate;
 	waveformat.nBlockAlign = waveformat.nChannels * waveformat.wBitsPerSample / 8;
     waveformat.nAvgBytesPerSec = waveformat.nSamplesPerSec * waveformat.nBlockAlign;
-	
+
 	CreateThread(NULL, 0, waveOutProc, cyd, 0, &cyd->cb_handle);
-	
+
 	MMRESULT result = waveOutOpen(&cyd->hWaveOut, 0, &waveformat, cyd->cb_handle, (DWORD)cyd, CALLBACK_THREAD);
-	
+
 	if (result != MMSYSERR_NOERROR)
 	{
 		warning("waveOutOpen failed (%x)", result);
 		return 0;
 	}
-	
+
 	for (int i = 0 ; i < CYD_NUM_WO_BUFFERS ; ++i)
 	{
 		WAVEHDR * h = &cyd->waveout_hdr[i];
-		
+
 		ZeroMemory(h, sizeof(*h));
-		
+
 		h->dwBufferLength = CYD_NUM_WO_BUFFER_SIZE * 2 * sizeof(Sint16);
 		h->lpData = calloc(h->dwBufferLength, 1);
-		
+
 		waveOutPrepareHeader(cyd->hWaveOut, &cyd->waveout_hdr[i],sizeof(WAVEHDR));
 	}
-	
+
 	cyd->buffers_available = CYD_NUM_WO_BUFFERS;
 	cyd->thread_running = 1;
-	
+
 	CreateThread(NULL, 0, ThreadProc, cyd, 0, &cyd->thread_handle);
 	SetThreadPriority((HANDLE)cyd->thread_handle, THREAD_PRIORITY_HIGHEST);
-	
+
 	return 1;
 # else
 
@@ -1260,7 +1268,7 @@ int cyd_register(CydEngine * cyd)
 
 int cyd_unregister(CydEngine * cyd)
 {
-	debug("cyd_unregister");	
+	debug("cyd_unregister");
 #ifndef USENATIVEAPIS
 # ifndef NOSDL_MIXER
 	int frequency, channels;
@@ -1273,24 +1281,24 @@ int cyd_unregister(CydEngine * cyd)
 			case 2: if (!Mix_UnregisterEffect(MIX_CHANNEL_POST, cyd_output_buffer_stereo)) return 0; break;
 			default: return 0; break;
 		}
-		
+
 		cyd_lock(cyd, 1);
 		cyd_lock(cyd, 0);
-		
+
 		return 1;
 	}
 	else return 0;
 # else
 
-	debug("Waiting for stuff");	
+	debug("Waiting for stuff");
 	cyd_lock(cyd, 1);
-	debug("Done waiting");	
+	debug("Done waiting");
 	cyd_lock(cyd, 0);
-	
-	debug("Closing audio");	
+
+	debug("Closing audio");
 	SDL_CloseAudio();
-	debug("SDL_CloseAudio finished");	
-	
+	debug("SDL_CloseAudio finished");
+
 	return 1;
 # endif
 #else
@@ -1302,7 +1310,7 @@ int cyd_unregister(CydEngine * cyd)
 	cyd->thread_running = 0;
 	cyd_lock(cyd, 0);
 	WaitForSingleObject((HANDLE)cyd->thread_handle, 2000);
-	
+
 	waveOutReset(cyd->hWaveOut);
 
 	for (int i = 0 ; i < CYD_NUM_WO_BUFFERS ; ++i)
@@ -1313,9 +1321,9 @@ int cyd_unregister(CydEngine * cyd)
 	}
 
 	waveOutClose(cyd->hWaveOut);
-	
+
 	WaitForSingleObject((HANDLE)cyd->cb_handle, 2000);
-		
+
 	return 1;
 #endif
 }
@@ -1362,8 +1370,8 @@ void cyd_lock(CydEngine *cyd, Uint8 enable)
 		{
 			SDL_Delay(1);
 		}
-	}	
-#else	
+	}
+#else
 	if (enable)
 	{
 		SDL_LockMutex(cyd->mutex);
@@ -1394,7 +1402,7 @@ void cyd_lock(CydEngine *cyd, Uint8 enable)
 void cyd_set_panning(CydEngine *cyd, CydChannel *chn, Uint8 panning)
 {
 	if (chn->panning == panning) return;
-	
+
 	chn->panning = my_min(CYD_PAN_RIGHT, my_max(CYD_PAN_LEFT, panning));
 	float a = M_PI / 2 * (float)(chn->panning - CYD_PAN_LEFT) / (CYD_PAN_RIGHT - CYD_PAN_LEFT);
 	chn->gain_left = cos(a) * CYD_STEREO_GAIN;
@@ -1406,7 +1414,7 @@ void cyd_set_panning(CydEngine *cyd, CydChannel *chn, Uint8 panning)
 void cyd_set_wave_entry(CydChannel *chn, const CydWavetableEntry * entry)
 {
 	chn->wave_entry = entry;
-	
+
 	for (int s = 0 ; s < CYD_SUB_OSCS ; ++s)
 	{
 		chn->subosc[s].wave.playing = true;
@@ -1444,12 +1452,12 @@ void cyd_pause(CydEngine *cyd, Uint8 enable)
 #endif
 #else
 	cyd_lock(cyd, 1);
-	
+
 	if (enable)
 		cyd->flags |= CYD_PAUSED;
 	else
 		cyd->flags &= ~CYD_PAUSED;
-	
+
 	cyd_lock(cyd, 0);
 #endif
 }


### PR DESCRIPTION
Given that attack and release have two different profiles (attack is
linear, while release is quadratic), triggering release in the middle
of attack would yield a discontinuity in the amp factor calculated in
cyd_env_output.