### PR TITLE
removal of typedef for menu_t

### DIFF
--- a/src/gui/menu.h
+++ b/src/gui/menu.h
@@ -33,7 +33,7 @@ struct menu_t
 	const struct menu_t *submenu;
 	void (*action)(void*, void*, void *);
 	void *p1, *p2, *p3;
-} menu_t;
+};
 
 enum { MENU_BULLET = 1 };
 #define MENU_CHECK (void*)1


### PR DESCRIPTION
Fixes https://github.com/kometbomb/klystrack/issues/295

I encountered no issues post-build.

Original issues was during build of klystron during a klystrack build on linux:
```multiple definition of `menu_t'```

If anyone has the means to give this a test and ensure there are no issues that arise, it would be appreciated.