### PR TITLE
Combine sequential mouse movement events

### DIFF
--- a/src/gui/filebox.c
+++ b/src/gui/filebox.c
@@ -795,9 +795,10 @@ int filebox(const char *title, int mode, char *buffer, size_t buffer_size, const
 
 			if (e.type != SDL_MOUSEMOTION || (e.motion.state)) ++got_event;
 
-			// ensure the last event is a mouse click so it gets passed to the draw/event code
-
-			if (e.type == SDL_MOUSEBUTTONDOWN || (e.type == SDL_MOUSEMOTION && e.motion.state)) break;
+			// Process mouse click events immediately, and batch mouse motion events
+			// (process the last one) to fix lag with high poll rate mice on Linux.
+			if (should_process_mouse(&e))
+				break;
 		}
 
 		if (data.selected)

--- a/src/gui/mouse.c
+++ b/src/gui/mouse.c
@@ -143,3 +143,24 @@ int check_drag_event(const SDL_Event *event, const SDL_Rect *rect, void (*action
 }
 
 
+int should_process_mouse(const SDL_Event *event)
+{
+	// If current event is a mouse click, break immediately to pass the event to the
+	// draw/event code.
+	if (event->type == SDL_MOUSEBUTTONDOWN)
+		return 1;
+
+	if (event->type == SDL_MOUSEMOTION)
+	{
+		// If the next event is not a mouse movement event with the same buttons held,
+		// process current mouse movement event immediately.
+		SDL_Event next_event;
+		if (SDL_PeepEvents(&next_event, 1, SDL_PEEKEVENT, SDL_MOUSEMOTION, SDL_MOUSEMOTION) <= 0)
+			return 1;
+		if (next_event.motion.state != event->motion.state)
+			return 1;
+	}
+	return 0;
+}
+
+

--- a/src/gui/mouse.h
+++ b/src/gui/mouse.h
@@ -32,3 +32,6 @@ void set_motion_target(void (*action)(int,int,void*), void *param);
 int check_event(const SDL_Event *event, const SDL_Rect *rect, void (*action)(void*,void*,void*), void *param1, void *param2, void *param3);
 int check_drag_event(const SDL_Event *event, const SDL_Rect *rect, void (*action)(int,int,void*), void *param);
 void set_repeat_timer(const SDL_Event *event);
+
+// Whether to immediately break the input polling loop and process the current mouse event.
+int should_process_mouse(const SDL_Event *event);

--- a/src/gui/msgbox.c
+++ b/src/gui/msgbox.c
@@ -169,9 +169,10 @@ int msgbox(GfxDomain *domain, GfxSurface *gfx, const Font *font, const char *msg
 			
 			if (e.type != SDL_MOUSEMOTION || (e.motion.state)) ++got_event;
 			
-			// ensure the last event is a mouse click so it gets passed to the draw/event code
-			
-			if (e.type == SDL_MOUSEBUTTONDOWN || (e.type == SDL_MOUSEMOTION && e.motion.state)) break; 
+			// Process mouse click events immediately, and batch mouse motion events
+			// (process the last one) to fix lag with high poll rate mice on Linux.
+			if (should_process_mouse(&e))
+				break;
 		}
 		
 		if (got_event || gfx_domain_is_next_frame(domain))


### PR DESCRIPTION
Previously on Linux (not Windows), if you opened Klystrack and dragged with a high polling rate mouse, the program would lag processing SDL_MOUSEMOTION events and redrawing the screen (https://github.com/kometbomb/klystrack/issues/299). This fixes the bug.